### PR TITLE
Chore: Add markdown link validation pre-commit hooks

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,20 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^mailto:"
+        },
+        {
+            "pattern": "^#"
+        }
+    ],
+    "replacementPatterns": [],
+    "httpHeaders": [],
+    "timeout": "5s",
+    "retryOn429": true,
+    "retryCount": 3,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [
+        200,
+        206
+    ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.2
+    hooks:
+      - id: markdown-link-check
+        args: ['--config', '.markdown-link-check.json']
+        types: [markdown]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Pre-Commit Hooks (Required)
+
+All contributors **must** install and run pre-commit hooks before committing.
+```bash
+uv pip install pre-commit
+pre-commit install
+```
+
+## Setup
+
 ```bash
 git clone https://github.com/vindicta-platform/Meta-Oracle.git
 cd Meta-Oracle


### PR DESCRIPTION
Add pre-commit hooks to validate markdown links across the repository. Standardizes documentation quality gates.